### PR TITLE
Make Rserve exceptions subclass StandardError instead of exception, so th

### DIFF
--- a/lib/rserve/connection.rb
+++ b/lib/rserve/connection.rb
@@ -5,12 +5,12 @@ module Rserve
     include Rserve::Protocol
 
     # :section: Exceptions
-    RserveNotStarted=Class.new(Exception)
-    ServerNotAvailable=Class.new(Exception)
-    IncorrectServer=Class.new(Exception)
-    IncorrectServerVersion=Class.new(Exception)
-    IncorrectProtocol=Class.new(Exception)
-    NotConnected=Class.new(Exception)
+    RserveNotStarted=Class.new(StandardError)
+    ServerNotAvailable=Class.new(StandardError)
+    IncorrectServer=Class.new(StandardError)
+    IncorrectServerVersion=Class.new(StandardError)
+    IncorrectProtocol=Class.new(StandardError)
+    NotConnected=Class.new(StandardError)
     # Eval error
     class EvalError < RuntimeError
       attr_accessor :request_packet


### PR DESCRIPTION
Make Rserve exceptions subclass StandardError instead of exception, so they can be rescued by `rescue` blocks.

A `rescue` block without anything after it will rescue StandardError or subclasses of it, but not subclasses of the Exception class. The Exception class is mostly subclassed by Ruby errors that you probably don't want to deal with, so making exceptions subclass StandardError is better.

My rescue block was letting Rserve exceptions through because they subclass Exception, not StandardError.
