### PR TITLE
Config throws warning fix

### DIFF
--- a/lib/rserve/protocol.rb
+++ b/lib/rserve/protocol.rb
@@ -9,7 +9,7 @@ module Rserve
   # See Rtalk class on Java version.
   module Protocol
     # Arch dependent Long Nil value 
-    case Config::CONFIG['arch']
+    case RbConfig::CONFIG['arch']
       when /i686-linux|mswin|mingw/
         LONG_NA=9221120237041092514 # :nodoc:
       else


### PR DESCRIPTION
`/home/USER/.rvm/gems/ruby-1.9.3-p0/gems/rserve-client-0.2.5/lib/rserve/protocol.rb:12: Use RbConfig instead of obsolete and deprecated Config.`

So, I've just updated the offending line of code.  Thanks.
