### PR TITLE
Incorrect Handling of infinite values

### DIFF
--- a/lib/rserve/rexp/double.rb
+++ b/lib/rserve/rexp/double.rb
@@ -35,7 +35,7 @@ module Rserve
       end
       def as_integers
         @payload.map do |v|
-          (na?(v) or infinite?(v)) ? nil : v.to_i
+          (na?(v) or Double.infinite?(v)) ? nil : v.to_i
         end
       end
       def as_doubles
@@ -57,7 +57,7 @@ module Rserve
         @payload.map {|v| _na?(v) }
       end
 
-      def infinite?(value)
+      def self.infinite?(value)
         value.respond_to?(:infinite?) and value.infinite?
       end
 

--- a/spec/rserve_double_spec.rb
+++ b/spec/rserve_double_spec.rb
@@ -33,6 +33,23 @@ describe Rserve::REXP::Double do
 
   end
 
+  describe "infinite?" do
+
+    it "should return false for non Float objects" do
+      Rserve::REXP::Double.infinite?(1).should be_false
+    end
+
+    it "should return false for non infinite floats" do
+      Rserve::REXP::Double.infinite?(Math::PI).should be_false
+    end
+
+    it "should return true for infinite floats" do
+      Rserve::REXP::Double.infinite?(-Float::INFINITY).should be_true
+      Rserve::REXP::Double.infinite?(Float::INFINITY).should be_true
+    end
+
+  end
+
   describe "common methods" do
     before do
       @n=rand(10)+10


### PR DESCRIPTION
When inspecting the content of an array for NaN/NA values, the code in `Double.na?` attempts a conversion to integer. This leads to an exception if the float value to be converted is an infinite one. I added an extra check to the `na?` code to verify that the float is finite before trying to convert it to an integer.

I also added an `infinite?` class method to Double to be used when converting floats to integer: when the float is infinite and it must be converted to a in integer, it will result in an NA  value.

I also added specs to verify that the behaviour is the desired one.
