### PR TITLE
No method exception when converting a "named Float" to ruby

### DIFF
--- a/lib/rserve/rexp.rb
+++ b/lib/rserve/rexp.rb
@@ -391,7 +391,7 @@ module Rserve
       #pp self
       v=to_ruby_internal
       #p v
-      if !v.nil? and !v.is_a? Fixnum and !v.is_a? TrueClass and !v.is_a? FalseClass
+      if !v.nil? and !v.is_a? Numeric and !v.is_a? TrueClass and !v.is_a? FalseClass
         v.extend Rserve::WithAttributes
         v.attributes=attr.to_ruby unless attr.nil?
         if !v.attributes.nil? and v.attributes.has_name? 'names'

--- a/spec/rserve_rexp_to_ruby_spec.rb
+++ b/spec/rserve_rexp_to_ruby_spec.rb
@@ -74,6 +74,11 @@ describe "Rserve::REXP#to_ruby" do
     it "should return an array of strings with a vector with two or more strings" do
       @r.eval("c('a','b',NA)").to_ruby.should==['a','b',nil]
     end
+    it "should handle named floats" do
+      @r.void_eval('y <- sample(1:100, 10)')
+      @r.void_eval('x <- sample(1:100, 10)')
+      @r.eval('lm(y ~ 0 + x)').to_ruby
+    end
     it "should return an array extended with Rserve::WithNames and Rserve::WithAttributes for a list" do
       expected=[1,2,3].extend Rserve::WithNames
       expected.names=%w{a b c}


### PR DESCRIPTION
When R returns an array of only one element the first internal convertsion (to class in the REXP module) strips away the array information and converts it directly into an instance of a subclass of `Numeric`. The problem arises when the array is also named because the module `WithNames` expects an Array and not a `Numeric`.
The current implementation was only checking for subclasses of `Fixnum`, replacing `Fixnum`with `Numeric`fixes the bug, but discards the name information. This is what this patch does, but it is only a band-aid that stops the exception, but does not cure the actual reason.

A more complete solution would be to also preserve the information, this could be achieved in two ways
- change the code such that an object with attribute `names` must always be a "complex" object, thus returning an array of one element, if need be
- add another module called `WithName` (singular) that adds a name instance variable to an object, and change the `to_ruby` method to extend `Numeric` objects with it, if need be.

The first approach is in my belief the cleanest as it is closer to the actual representation, but it may not be backward compatible
The second approach is a bit more hackish, but is backward compatible.

So I let it up to you to decide which method fits best with your idea of the library.
