### PR TITLE
Raw expression transfer to rserve error.

### DIFF
--- a/lib/rserve/protocol/rexpfactory.rb
+++ b/lib/rserve/protocol/rexpfactory.rb
@@ -617,6 +617,11 @@ module Rserve
           set_int(by.length,buf,off);
           off+=4
           by.each_with_index {|v,i| buf[off+i]=v}
+		  off+=by.length
+		  while ((off & 3) != 0)
+            buf[off] = 0
+            off+=1
+          end
         elsif(rxt==XT_ARRAY_STR)
           sa=cont.as_strings
           io=off


### PR DESCRIPTION
Working with serializing and unserializing raw R expressions. Serializing and reading in ruby works fine and the binary data is consistent with what R has. Sending that same raw data back to R throws exception ":cont shouldn't contain anything but Fixnum" from talk.rb. Found out size of data was more than received but was not actually padded up. Fix is in the rexpfactory.rb where for raw expression padding to size divisible by 4 is not done.
