### PR TITLE
Add support for crypt and plaintext authentication.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem 'hoe'
 gem 'rspec'
 gem 'rake'
+gem 'rbx-require-relative', :platforms => :ruby_18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     hoe (3.12.0)
       rake (>= 0.8, < 11.0)
     rake (10.3.2)
+    rbx-require-relative (0.0.9)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -24,4 +25,5 @@ PLATFORMS
 DEPENDENCIES
   hoe
   rake
+  rbx-require-relative
   rspec

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Cons:
 
 Implements
 
-* Authentification
 * Original test
 
 Spec

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,9 @@ $:.unshift(File.dirname(__FILE__)+"/lib")
 require 'rubygems'
 require 'rserve'
 require 'rspec'
-require 'rspec/core/rake_task'
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
 # vim: syntax=ruby

--- a/data/Rserv-cryptonly.conf.example
+++ b/data/Rserv-cryptonly.conf.example
@@ -1,0 +1,4 @@
+port 6313
+auth required
+plaintext disable
+remote enable

--- a/data/Rserv-plaintext.conf.example
+++ b/data/Rserv-plaintext.conf.example
@@ -1,0 +1,4 @@
+port 6312
+auth required
+plaintext enable
+remote enable

--- a/data/Rserv.passwords
+++ b/data/Rserv.passwords
@@ -1,0 +1,1 @@
+test password

--- a/lib/rserve.rb
+++ b/lib/rserve.rb
@@ -6,21 +6,22 @@ module Rserve
 end
 
 require 'spoon' if RUBY_PLATFORM == "java"
+require 'require_relative' if RUBY_VERSION < "1.9"
 
-require 'rserve/withnames'
-require 'rserve/withattributes'
-require 'rserve/with2dnames'
-require 'rserve/with2dsizes'
+require_relative 'rserve/withnames'
+require_relative 'rserve/withattributes'
+require_relative 'rserve/with2dnames'
+require_relative 'rserve/with2dsizes'
 
 
-require 'rserve/protocol'
-require 'rserve/packet'
-require 'rserve/talk'
-require 'rserve/rexp'
-require 'rserve/engine'
-require 'rserve/session'
-require 'rserve/connection'
-require 'rserve/rlist'
-require 'rserve/rfactor'
+require_relative 'rserve/protocol'
+require_relative 'rserve/packet'
+require_relative 'rserve/talk'
+require_relative 'rserve/rexp'
+require_relative 'rserve/engine'
+require_relative 'rserve/session'
+require_relative 'rserve/connection'
+require_relative 'rserve/rlist'
+require_relative 'rserve/rfactor'
 
 

--- a/lib/rserve/connection.rb
+++ b/lib/rserve/connection.rb
@@ -10,6 +10,7 @@ module Rserve
     IncorrectServerError=Class.new(StandardError)
     IncorrectServerVersionError=Class.new(StandardError)
     IncorrectProtocolError=Class.new(StandardError)
+    IncorrectCredentialsError=Class.new(StandardError)
     NotConnectedError=Class.new(StandardError)
     # Eval error
     class EvalError < RuntimeError
@@ -41,12 +42,14 @@ module Rserve
     # You could provide a hash with options. Options are analog to java client:
     # [+:auth_req+]           If authentification is required (false by default)
     # [+:transfer_charset+]   Transfer charset ("UTF-8" by default)
-    # [+:auth_type+]          Type of authentification (AT_plain by default)
+    # [+:auth_type+]          Type of authentication (AT_plain by default)
     # [+:hostname+]           Hostname of Rserve ("127.0.0.1" by default)
     # [+:port_number+]        Port Number of Rserve (6311 by default)
     # [+:max_tries+]          Maximum number of tries before give up  (5 by default)
-    # [+:cmd_init+]            Command to init Rserve if not initialized ("R CMD Rserve" by default)
-    # [+:proc_rserve_ok+]      Proc testing if Rserve works (uses system by default)
+    # [+:cmd_init+]           Command to init Rserve if not initialized ("R CMD Rserve" by default)
+    # [+:proc_rserve_ok+]     Proc testing if Rserve works (uses system by default)
+    # [+:username+]           Username to use (if authentication is required)
+    # [+:password+]           Password to use (if authentication is required)
     def initialize(opts=Hash.new)
       @auth_req         = opts.delete(:auth_req)          || false
       @transfer_charset = opts.delete(:transfer_charset)  || "UTF-8"
@@ -56,6 +59,8 @@ module Rserve
       @max_tries        = opts.delete(:max_tries)         || 5
       @cmd_init         = opts.delete(:cmd_init)          || "R CMD Rserve"
       @proc_rserve_ok   = opts.delete(:proc_rserve_ok)    || lambda { system "killall -s 0 Rserve" } 
+      @username         = opts.delete(:username)          || nil
+      @password         = opts.delete(:password)          || nil
       @session          = opts.delete(:session)           || nil
       @tries            = 0
       @connected=false
@@ -115,20 +120,15 @@ module Rserve
         (3..7).each do |i|
           attr=input[i]
           if (attr=="ARpt") 
-            if (!auth_req) # this method is only fallback when no other was specified
-              auth_req=true
-              auth_type=AT_plain
-            end
+            @auth_req=true
+          elsif (attr=="ARuc") 
+            @auth_req=true
+            @auth_type=AT_crypt #
+          elsif (attr[0..0]=='K') 
+            @key=attr[1,2]
           end
-          if (attr=="ARuc") 
-            auth_req=true
-            authType=AT_crypt
-          end
-          if (attr[0]=='K') 
-            key=attr[1,3]
-          end
-          
         end
+        login if auth_req
       else # we have a session to take care of
         @s.write(@session.key.pack("C*"))
         @rsrv_version=session.rsrv_version
@@ -141,6 +141,14 @@ module Rserve
     # return +true+ if this connection is alive 
     def connected?
       @connected
+    end
+    
+    # This server requires a login. Send the required credentials to the server.
+    def login
+      raise IncorrectCredentialsError, "Need username and password to connect" if @username.nil? || @password.nil?
+      @password = @password.crypt(key) if key && auth_type == AT_crypt
+      rp = @rt.request({:cmd => Rserve::Protocol::CMD_login, :cont => "#{@username}\n#{@password}"})
+      raise IncorrectCredentialsError, "Server did not accept credentials" if rp.error?
     end
     
     # Closes current connection

--- a/lib/rserve/packet.rb
+++ b/lib/rserve/packet.rb
@@ -6,6 +6,7 @@ module Rserve
     ERROR_DESCRIPTIONS={
       2=>'Invalid expression',
       3=>'Parse error',
+     65=>'Login error',
     127=>'Unknown variable/method'}
 
     def initialize(cmd, cont)

--- a/lib/rserve/protocol.rb
+++ b/lib/rserve/protocol.rb
@@ -230,4 +230,4 @@ module Rserve
   end
 end
 
-require 'rserve/protocol/rexpfactory'
+require_relative 'protocol/rexpfactory'

--- a/lib/rserve/rexp.rb
+++ b/lib/rserve/rexp.rb
@@ -424,32 +424,32 @@ module Rserve
 end
     
     
-require 'rserve/rexp/environment'
-require 'rserve/rexp/null'
-require 'rserve/rexp/unknown'
+require_relative 'rexp/environment'
+require_relative 'rexp/null'
+require_relative 'rexp/unknown'
 
 
-require 'rserve/rexp/vector'
+require_relative 'rexp/vector'
 
-require 'rserve/rexp/raw'
-require 'rserve/rexp/symbol'
-require 'rserve/rexp/string'
-require 'rserve/rexp/double'
-require 'rserve/rexp/integer'
-require 'rserve/rexp/logical'
+require_relative 'rexp/raw'
+require_relative 'rexp/symbol'
+require_relative 'rexp/string'
+require_relative 'rexp/double'
+require_relative 'rexp/integer'
+require_relative 'rexp/logical'
 
-require 'rserve/rexp/factor'
+require_relative 'rexp/factor'
 
-require 'rserve/rexp/genericvector'
-require 'rserve/rexp/expressionvector'
+require_relative 'rexp/genericvector'
+require_relative 'rexp/expressionvector'
 
 
-require 'rserve/rexp/list'
-require 'rserve/rexp/language'
-require 'rserve/rexp/s4'
+require_relative 'rexp/list'
+require_relative 'rexp/language'
+require_relative 'rexp/s4'
 
-require 'rserve/rexp/reference'
+require_relative 'rexp/reference'
 
-require 'rserve/rexp/wrapper'
-require 'rserve/rexp/function'
+require_relative 'rexp/wrapper'
+require_relative 'rexp/function'
 

--- a/spec/rserve_connection_authentication_spec.rb
+++ b/spec/rserve_connection_authentication_spec.rb
@@ -1,0 +1,70 @@
+require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
+require 'tempfile'
+
+describe Rserve::Connection do
+  before(:all) do
+    lambda { system "killall Rserve" }.call #clean up any extra Rserves
+    password_file = File.expand_path("./data/Rserv.passwords")
+    
+    plain_config = IO.read('./data/Rserv-plaintext.conf.example')
+    plain_config = plain_config + "\npwdfile #{password_file}\n"
+    @plain_config_file = Tempfile.new('Rserv-plaintext.conf')
+    @plain_config_file.write(plain_config)
+    @plain_config_file.flush
+    crypt_config = IO.read('./data/Rserv-cryptonly.conf.example')
+    crypt_config = crypt_config + "\npwdfile #{password_file}\n"
+    @crypt_config_file = Tempfile.new('Rserv-cryptonly.conf')
+    @crypt_config_file.write(crypt_config)
+    @crypt_config_file.flush
+  end
+  describe "opening and closing plaintext" do
+    before(:all) do
+      @r=Rserve::Connection.new(:cmd_init => "R CMD Rserve --RS-conf #{@plain_config_file.path}", :username => "test", :password => "password", :port_number => 6312)
+    end
+    it "should be open a connection and receive ID-String" do
+      @r.get_server_version.should==103
+      @r.protocol.should=="QAP1"
+      @r.last_error.should=="OK"
+      @r.rt.should be_instance_of(Rserve::Talk)
+    end
+    it "should eval something properly" do
+      @r.void_eval("x<-1").should be true
+    end
+    it "should shut down correctly" do
+      @r.should be_connected
+      @r.close.should be true
+      @r.should_not be_connected
+    end
+  end
+  describe "opening and closing plaintext wrong password" do
+    it "should fail to connect" do
+      expect {@r=Rserve::Connection.new(:cmd_init => "R CMD Rserve --RS-conf #{@plain_config_file.path}", :username => "test", :password => "wrongpassword", :port_number => 6312)}.to raise_error(Rserve::Connection::IncorrectCredentialsError)
+      lambda { system "killall Rserve" }.call #clean up any extra Rserves
+    end
+  end
+  describe "opening and closing crypt" do
+    before(:all) do
+      @r=Rserve::Connection.new(:cmd_init => "R CMD Rserve --RS-conf #{@crypt_config_file.path}", :username => "test", :password => "password", :port_number => 6313)
+    end
+    it "should be open a connection and receive ID-String" do
+      @r.get_server_version.should==103
+      @r.protocol.should=="QAP1"
+      @r.last_error.should=="OK"
+      @r.rt.should be_instance_of(Rserve::Talk)
+    end
+    it "should eval something properly" do
+      @r.void_eval("x<-1").should be true
+    end
+    it "should shut down correctly" do
+      @r.should be_connected
+      @r.close.should be true
+      @r.should_not be_connected
+    end
+  end
+  describe "opening and closing crypt wrong password" do
+    it "should fail to connect" do
+      expect {@r=Rserve::Connection.new(:cmd_init => "R CMD Rserve --RS-conf #{@crypt_config_file.path}", :username => "test", :password => "wrongpassword", :port_number => 6313)}.to raise_error(Rserve::Connection::IncorrectCredentialsError)
+      lambda { system "killall Rserve" }.call #clean up any extra Rserves
+    end
+  end
+end

--- a/spec/rserve_connection_on_unix_spec.rb
+++ b/spec/rserve_connection_on_unix_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe "Rserve::Connection on unix" do
   if !Rserve::ON_WINDOWS
     before do
-        @r=Rserve::Connection.new
+      @r=Rserve::Connection.new
     end
     after do
       @r.close if @r.connected?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rserve'
 require 'matrix'
 require 'pp'
 
+INFINITY = +1.0/0.0 if RUBY_VERSION < "1.9"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|


### PR DESCRIPTION
Update readme to reflection that authentication works now.
Making both gem and tests happy on Ruby 1.8.7.
Throwing in some tests that should allow testing of plain and crypt auth scenarios, too.
