### PR TITLE
Remove `FixNum` usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language:
   ruby
 
 rvm:
-  - '2.3.1'
-  - '2.4'
+  - '2.7.8'
+  - '3.0.6'
+  - '3.1.4'
+  - '3.2.2'
 script:
   bundle exec rake
   

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+=== unreleased
+* Remove usage of Fixnum, since this class is removed in ruby 3.2
+
 === 0.3.4 / 2017-08-27
 
 * Updated rserve_talk_spec to latest rspec

--- a/examples/regression.rb
+++ b/examples/regression.rb
@@ -35,7 +35,7 @@ est=r.eval("est").to_ruby
 puts "E(y|x) ~= #{est['(Intercept)'].to_f} + #{est['x'].to_f} * x"
 
 # fit$pvalue is a vector of size 1. So, the method #to_ruby
-# retrieves a rational or a Fixnum, according to original representation
+# retrieves a rational or a Integer, according to original representation
 
 if r.eval("pvalue").to_ruby < alpha
  puts "Reject the null hypothesis and conclude that x and y are related."

--- a/lib/rserve/rexp/wrapper.rb
+++ b/lib/rserve/rexp/wrapper.rb
@@ -21,9 +21,7 @@ module Rserve
             REXP::Null.new()
           when ::String
             REXP::String.new(o)
-          when Integer
-            REXP::Integer.new(o)
-          when Fixnum
+          when ::Integer
             REXP::Integer.new(o)
           when Float
             REXP::Double.new(o)
@@ -53,7 +51,7 @@ module Rserve
       def self.find_type_of_array(o)
         if o.all? {|v| v.nil?}
           REXP::Integer.new([REXP::Integer::NA]*o.size)
-        elsif o.all? {|v| v.is_a? Integer or v.is_a? Fixnum or v.nil?}
+        elsif o.all? {|v| v.is_a? Integer or v.nil?}
           REXP::Integer.new(o.map {|v| v.nil? ? REXP::Integer::NA : v})
         elsif o.all? {|v| v.is_a? Numeric or v.nil?}
           REXP::Double.new(o.map {|v| v.nil? ? REXP::Double::NA : v.to_f})

--- a/lib/rserve/talk.rb
+++ b/lib/rserve/talk.rb
@@ -41,7 +41,7 @@ module Rserve
 
 
       if (!cont.nil?)
-        raise ":cont shouldn't contain anything but Fixnum" if cont.any? {|v| v.class != 1.class}
+        raise ":cont shouldn't contain anything but Integer" if cont.any? {|v| v.class != 1.class}
         if (offset>=cont.length)
           cont=nil;len=0
         elsif (len>cont.length-offset)

--- a/spec/rserve_rexp_to_ruby_spec.rb
+++ b/spec/rserve_rexp_to_ruby_spec.rb
@@ -9,14 +9,14 @@ describe "Rserve::REXP#to_ruby" do
     after do
       @r.close
     end
-    it "should return a Fixnum with vector with one integer element" do
+    it "should return a Integer with vector with one integer element" do
       @r.eval("1").to_ruby.should==1
     end
-    it "should return an array of Fixnum and nils with vector with two or more elements" do
+    it "should return an array of Integer and nils with vector with two or more elements" do
       @r.eval("c(1,2,3,NA)").to_ruby.should==[1,2,3,nil]
     end
     
-    it "should return an array of Fixnum with an enumeration" do
+    it "should return an array of Integer with an enumeration" do
       @r.eval("1:10").to_ruby.should==[1,2,3,4,5,6,7,8,9,10]
     end
     it "should return an array of String with a factor" do


### PR DESCRIPTION
Fix #29 

`FixNum` has been deprecated since ruby 2.5 (which is already EOL) and has been completely removed in ruby 3.2.

I also updated the test matrix to only test rubies which still receive support. Feel free to disregard that commit